### PR TITLE
Release old reservation functionality implemented

### DIFF
--- a/app/src/main/java/com/example/parkingsystemkotlin/activity/ParkingSpaceReservationActivity.kt
+++ b/app/src/main/java/com/example/parkingsystemkotlin/activity/ParkingSpaceReservationActivity.kt
@@ -8,6 +8,7 @@ import android.os.Bundle
 import android.widget.DatePicker
 import android.widget.TimePicker
 import androidx.appcompat.app.AppCompatActivity
+import com.example.parkingsystemkotlin.database.ParkingSpaceReservationDB
 import com.example.parkingsystemkotlin.databinding.ActivityReservationParkingSpaceBinding
 import com.example.parkingsystemkotlin.mvp.contract.ParkingSpaceReservationContract
 import com.example.parkingsystemkotlin.mvp.model.ParkingSpaceReservationModel
@@ -23,7 +24,11 @@ class ParkingSpaceReservationActivity : AppCompatActivity(), DatePickerDialog.On
         super.onCreate(savedInstanceState)
         binding = ActivityReservationParkingSpaceBinding.inflate(layoutInflater)
         setContentView(binding.root)
-        presenter = ParkingSpaceReservationPresenter(ParkingSpaceReservationModel(), ParkingSpaceReservationView(this, binding))
+        presenter = ParkingSpaceReservationPresenter(
+            ParkingSpaceReservationModel(ParkingSpaceReservationDB),
+            ParkingSpaceReservationView(this, binding)
+        )
+        clearPastReservations()
         setListeners()
     }
 
@@ -35,8 +40,12 @@ class ParkingSpaceReservationActivity : AppCompatActivity(), DatePickerDialog.On
         presenter.onTimeSetPressed(hourOfDay, minute)
     }
 
+    private fun clearPastReservations() {
+        presenter.clearOldReservations()
+    }
+
     private fun setListeners() {
-        with(binding){
+        with(binding) {
             buttonParkingSpaceReservationPickerBegin.setOnClickListener { presenter.onButtonParkingSpaceReservationPickerPressed(this@ParkingSpaceReservationActivity) }
             buttonParkingSpaceReservationPickerEnd.setOnClickListener { presenter.onButtonParkingSpaceReservationPickerPressed(this@ParkingSpaceReservationActivity) }
             buttonParkingSpaceReservationSave.setOnClickListener { presenter.onButtonParkingSpaceReservationSavePressed() }

--- a/app/src/main/java/com/example/parkingsystemkotlin/database/ParkingSpaceReservationDB.kt
+++ b/app/src/main/java/com/example/parkingsystemkotlin/database/ParkingSpaceReservationDB.kt
@@ -1,6 +1,7 @@
 package com.example.parkingsystemkotlin.database
 
 import com.example.parkingsystemkotlin.entity.Reservation
+import java.util.Calendar
 
 object ParkingSpaceReservationDB {
     val hashReservation: MutableMap<Int, MutableList<Reservation>> = HashMap()
@@ -14,6 +15,15 @@ object ParkingSpaceReservationDB {
         reservations?.let {
             it.add(reservation)
             hashReservation.put(parkingSpace, it)
+        }
+    }
+
+    fun releasePastReservations() {
+        hashReservation.forEach { (reservationList, _) ->
+            hashReservation[reservationList]?.removeAll { reservation -> Calendar.getInstance().after(reservation.dateEnd) }
+            if (hashReservation[reservationList].isNullOrEmpty()) {
+                hashReservation.remove(reservationList)
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/parkingsystemkotlin/mvp/contract/ParkingSpaceReservationContract.kt
+++ b/app/src/main/java/com/example/parkingsystemkotlin/mvp/contract/ParkingSpaceReservationContract.kt
@@ -13,6 +13,7 @@ interface ParkingSpaceReservationContract {
         fun onDateSetPressed(year: Int, month: Int, dayOfMonth: Int, timeListener: TimePickerDialog.OnTimeSetListener)
         fun onTimeSetPressed(hourOfDay: Int, minute: Int)
         fun onButtonParkingSpaceReservationSavePressed()
+        fun clearOldReservations()
     }
 
     interface ParkingSpaceReservationModel {
@@ -33,6 +34,7 @@ interface ParkingSpaceReservationContract {
         fun getReservationVerifyResult(): ReservationVerifiyResult
         fun getValidReservation(): ReservationVerifiyResult
         fun makeReservation(reservation: Reservation)
+        fun releaseOldReservations()
     }
 
     interface ParkingSpaceReservationView {
@@ -52,5 +54,6 @@ interface ParkingSpaceReservationContract {
         fun showMissingSecurityCode()
         fun showReservationOverlapping()
         fun showReservationSuccess()
+        fun showPastReservationsReleased(amountReservations: Int)
     }
 }

--- a/app/src/main/java/com/example/parkingsystemkotlin/mvp/model/ParkingSpaceReservationModel.kt
+++ b/app/src/main/java/com/example/parkingsystemkotlin/mvp/model/ParkingSpaceReservationModel.kt
@@ -10,10 +10,11 @@ import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
 
-class ParkingSpaceReservationModel : ParkingSpaceReservationContract.ParkingSpaceReservationModel {
+class ParkingSpaceReservationModel(private val database: ParkingSpaceReservationDB) :
+    ParkingSpaceReservationContract.ParkingSpaceReservationModel {
     private var isDateStartButtonPressed = false
     private val reservation = Reservation()
-    private val reservationChecker = ReservationChecker(ParkingSpaceReservationDB)
+    private val reservationChecker = ReservationChecker(database)
 
     override fun setDateStartButtonPressed(isDateStartButtonPressed: Boolean) {
         this.isDateStartButtonPressed = isDateStartButtonPressed
@@ -70,5 +71,9 @@ class ParkingSpaceReservationModel : ParkingSpaceReservationContract.ParkingSpac
 
     override fun makeReservation(reservation: Reservation) {
         ParkingSpaceReservationDB.addReservation(reservation)
+    }
+
+    override fun releaseOldReservations() {
+        database.releasePastReservations()
     }
 }

--- a/app/src/main/java/com/example/parkingsystemkotlin/mvp/presenter/ParkingSpaceReservationPresenter.kt
+++ b/app/src/main/java/com/example/parkingsystemkotlin/mvp/presenter/ParkingSpaceReservationPresenter.kt
@@ -68,4 +68,7 @@ class ParkingSpaceReservationPresenter(
             }
         }
     }
+    override fun clearOldReservations() {
+        model.releaseOldReservations()
+    }
 }

--- a/app/src/main/java/com/example/parkingsystemkotlin/mvp/view/ParkingSpaceReservationView.kt
+++ b/app/src/main/java/com/example/parkingsystemkotlin/mvp/view/ParkingSpaceReservationView.kt
@@ -104,4 +104,10 @@ class ParkingSpaceReservationView(activity: Activity, private val binding: Activ
         }
         activity?.finish()
     }
+
+    override fun showPastReservationsReleased(amountReservations: Int) {
+        context?.let {
+            it.toast(it.getString(R.string.toast_parking_space_reservation_amount_reserves_released, amountReservations))
+        }
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,4 +23,5 @@
     <string name="toast_parking_space_reservation_missing_security_code">Please, put the security code in the field</string>
     <string name="toast_parking_space_reservation_reservation_overlapping">This date has already booked. Please select another date</string>
     <string name="toast_parking_space_reservation_save">Your reservation was made successfully</string>
+    <string name="toast_parking_space_reservation_amount_reserves_released">%1$d reserves have been released</string>
 </resources>

--- a/app/src/test/java/com/example/parkingsystemkotlin/mvp/presenter/ParkingSpaceReservationPresenterTest.kt
+++ b/app/src/test/java/com/example/parkingsystemkotlin/mvp/presenter/ParkingSpaceReservationPresenterTest.kt
@@ -2,6 +2,7 @@ package com.example.parkingsystemkotlin.mvp.presenter
 
 import android.app.DatePickerDialog
 import android.app.TimePickerDialog
+import com.example.parkingsystemkotlin.database.ParkingSpaceReservationDB
 import com.example.parkingsystemkotlin.entity.Reservation
 import com.example.parkingsystemkotlin.mvp.contract.ParkingSpaceReservationContract
 import com.example.parkingsystemkotlin.mvp.model.ParkingSpaceReservationModel
@@ -22,7 +23,7 @@ class ParkingSpaceReservationPresenterTest {
 
     @Before
     fun setup() {
-        model = ParkingSpaceReservationModel()
+        model = ParkingSpaceReservationModel(ParkingSpaceReservationDB)
         presenter = ParkingSpaceReservationPresenter(model, view)
     }
 
@@ -251,6 +252,11 @@ class ParkingSpaceReservationPresenterTest {
         verify(view).showReservationSuccess()
     }
 
+    @Test
+    fun`on activity creates, the old reservations are released`(){
+        presenter.clearOldReservations()
+    }
+
     companion object {
         private const val YEAR = 2021
         private const val MONTH = 8
@@ -274,6 +280,5 @@ class ParkingSpaceReservationPresenterTest {
         private const val PARKING_SPACE_INT = 2
         private const val SECURITY_CODE_INT = 873
         private const val EMPTY_STRING = ""
-
     }
 }


### PR DESCRIPTION
-Automatic release of old reservation when the reservation activity starts

**Folder Structure**
![image](https://user-images.githubusercontent.com/84337427/127896136-c448ebd0-aa72-4625-886b-9ed3359be9c7.png)

**Database with 3 reservations (the last is an old reservation)**
![image](https://user-images.githubusercontent.com/84337427/127895881-8328525d-8cbd-4044-b513-ebbb5781fbe0.png)

**Database when the reservation activity starts, without the old reservation**
![image](https://user-images.githubusercontent.com/84337427/127896003-868c370f-a3c8-4baa-8687-6b76c02b25c8.png)

**Unit test**
![image](https://user-images.githubusercontent.com/84337427/127894742-7564d114-eefa-4376-987f-0696c42b117b.png)

**Unit test coverage**
![image](https://user-images.githubusercontent.com/84337427/127894815-deda3b65-0fbd-4239-9c58-b9b4fde9d973.png)

